### PR TITLE
fixes

### DIFF
--- a/FileBot.conf
+++ b/FileBot.conf
@@ -1,3 +1,3 @@
 MAX_WAIT_TIME=60
-WATCH_PATH=./input
-OUTPUT_PATH=./media
+WATCH_PATH=/usr/input
+OUTPUT_PATH=/usr/output

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,11 @@
+services:
+  docker-filebot:
+    container_name: filebot
+    volumes:
+      - ./config:/config
+      - ./input:/usr/input
+      - ./movies:/usr/output/movies
+      - ./tv_shows:/usr/output/tv_shows
+      - ./music:/usr/output/music
+      - ./reports:/usr/output/reports
+    image: tmcphee/docker-filebot

--- a/filebot.sh
+++ b/filebot.sh
@@ -5,8 +5,8 @@
 
 #-----------------------------------------------------------------------------------------------------------------------
 
-INPUT_DIR=%1
-OUTPUT_DIR=%2
+INPUT_DIR="$1"
+OUTPUT_DIR="$2"
 
 #-----------------------------------------------------------------------------------------------------------------------
 
@@ -14,31 +14,46 @@ QUOTE_FIXER='replaceAll(/[\`\u00b4\u2018\u2019\u02bb]/, "'"'"'").replaceAll(/[\u
 
 # Customize the renaming format here. For info on formatting: https://www.filebot.net/naming.html
 
-# Music/Eric Clapton/From the Cradle/05 - It Hurts Me Too.mp3
-MUSIC_FORMAT="MUSIC/{artist}/{album} ({y})/{pi.pad(2)} {t} - {artist} [{kbps}]"
+# music/Eric Clapton/From the Cradle/05 - It Hurts Me Too.mp3
+MUSIC_FORMAT="music/{artist}/{album} ({y})/{pi.pad(2)} {t} - {artist} [{kbps}]"
 
-# Movies/Fight Club.mkv
-MOVIE_FORMAT="MOVIES/{n} ({y}) [{vf}] [{source}] [{ac} {channels}]/{n}"
+# movies/Fight Club.mkv
+MOVIE_FORMAT="movies/{n} ({y}) [{vf}] [{source}] [{ac} {channels}]/{n}"
 
-# TV Shows/Game of Thrones/Season 05/Game of Thrones - S05E08 - Hardhome.mp4
-# TV Shows/Game of Thrones/Special/Game of Thrones - S00E11 - A Day in the Life.mp4
-SERIES_FORMAT="TV/{n}/Season {s.pad(2)}/{n} - {s00e00} - {t}"
+# tv_shows/Game of Thrones/Season 05/Game of Thrones - S05E08 - Hardhome.mp4
+SERIES_FORMAT="tv_shows/{n}/Season {s.pad(2)}/{n} - {s00e00} - {t}"
+
+# Language code for file names
+# en, de, es, ...
+LANGUAGE="en"
+
+# f.e. https://plex.domain.de:EQeDASSRWDFGGFxSSF
+PLEX_API_KEY=""
+
+# y or n
+MUSIC=y
 
 #-----------------------------------------------------------------------------------------------------------------------
 
 # Used to detect old versions of this script
-VERSION=5
+VERSION=6
 
 # See http://www.filebot.net/forums/viewtopic.php?t=215 for details on amc
-filebot -script files/scripts/amc.groovy -no-xattr --output "$OUTPUT_DIR" --log-file /files/amc.log --action move --conflict auto \
-  -non-strict --def ut_dir="$INPUT_DIR" ut_kind=multi music=y deleteAfterExtract=y clean=y \
-  excludeList=/config/amc-exclude-list.txt \
-  movieFormat="$MOVIE_FORMAT" musicFormat="$MUSIC_FORMAT" seriesFormat="$SERIES_FORMAT"
-
-if [ "$ALLOW_REPROCESSING" = "yes" ]; then
-  tempfile=$(mktemp)
-  # FileBot only puts files that it can process into the amc-exclude-list.txt file. e.g. jpg files are not in there. So
-  # take the intersection of the existing files and the ones in the list.
-  comm -12 <(sort /config/amc-exclude-list.txt) <(find /input | sort) > $tempfile
-  mv -f $tempfile /config/amc-exclude-list.txt
-fi
+filebot \
+  -script files/scripts/amc.groovy \
+  -non-strict \
+  "$INPUT_DIR" \
+  --output "$OUTPUT_DIR" \
+  --action move \
+  --conflict skip \
+  --lang="$LANGUAGE" \
+  --def plex="$PLEX_API_KEY" \
+  --def movieFormat="$MOVIE_FORMAT" \
+  --def musicFormat="$MUSIC_FORMAT" \
+  --def seriesFormat="$SERIES_FORMAT" \
+  --def skipExtract=y \
+  --def music="$MUSIC" \
+  --def unsorted=y \
+  --def ignore="Unsorted" \
+  --def clean=y \
+  --def storeReport="$OUTPUT_DIR"/reports

--- a/start.sh
+++ b/start.sh
@@ -30,7 +30,7 @@ echo "$(ts) Checking for config/FileBot.conf"
 if [ ! -f /config/FileBot.conf ]
 	then
 		echo "$(ts) Creating /config/FileBot.conf"
-		cp /files/filebot.sh /config/FileBot.conf
+		cp /files/FileBot.conf /config/FileBot.conf
 		chmod a+wx /config/FileBot.conf
 	else
 		echo "$(ts) config/FileBot.conf Exists"


### PR DESCRIPTION
I fixed a lot of things. It should now work as expected.
IMO, an exclude list is not necessary if the output directory does not match the input directory.

But what I saw: In your version, but also in mine, FileBot "moves" the files with copy and delete. This leads to unnecessary write cycles, CPU load and movement time. Maybe you have an idea? --action move is set...